### PR TITLE
Added quotes around * as correct syntax

### DIFF
--- a/whats-new/masonite-2.2.md
+++ b/whats-new/masonite-2.2.md
@@ -118,13 +118,13 @@ $ craft serve --dont-reload
 Learn more in the [Craft commands documentation here](../the-craft-command/introduction.md#running-the-wsgi-server).
 {% endhint %}
 
-## Added Accept\(\*\) to drivers
+## Added Accept\('\*\') to drivers
 
-By default you can only upload image files because of security reasons but now you can disable that by doing an accept\(\*\) option:
+By default you can only upload image files because of security reasons but now you can disable that by doing an accept\('\*\') option:
 
 ```python
 def show(self, upload: Upload):
-    upload.accept(*).store(request.input('file'))
+    upload.accept('*').store(request.input('file'))
 ```
 
 {% hint style="success" %}


### PR DESCRIPTION
Added missing quotes around the "*" character for correct syntax (and to match full documentation)