### PR TITLE
Fix test so it handles the newline added by print

### DIFF
--- a/useful-features/testing.md
+++ b/useful-features/testing.md
@@ -226,7 +226,7 @@ def test_get_output(self):
     with self.captureOutput() as o:
         print('hello world!')
 
-    self.assertEqual(o.getvalue(), 'hello world!')
+    self.assertEqual(o.getvalue().rstrip(), 'hello world!')
 ```
 
 ## Testing JSON


### PR DESCRIPTION
@josephmancuso made the important change to the documentation to add the getvalue() call when capturing output, however the test still fails. This is because there is a line feed added by the print statement.

I updated the example code so it works correctly:
self.assertEqual(o.getvalue().rstrip(), 'hello world!')