### PR TITLE
Correct parameter name to override request method

### DIFF
--- a/the-basics/requests.md
+++ b/the-basics/requests.md
@@ -714,7 +714,7 @@ This will look like:
 
 ```markup
 <form action="/dashboard" method="POST">
-    <input type="hidden" name="request_method" value="PATCH">
+    <input type="hidden" name="__method" value="PATCH">
 </form>
 ```
 
@@ -726,7 +726,7 @@ or you can optionally use a helper method:
 </form>
 ```
 
-When the form is submitted, it will process as a PUT request instead of a POST request.
+When the form is submitted, it will process as a PATCH request instead of a POST request.
 
 This will allow this form to hit a route like this:
 
@@ -734,7 +734,7 @@ This will allow this form to hit a route like this:
 from masonite.routes import Patch
 
 ROUTES = [
-    Patch().route('/dashboard', 'DashboardController@update')
+    Patch('/dashboard', 'DashboardController@update')
 ]
 ```
 


### PR DESCRIPTION
As discussed on Slack, this corrects the parameter name to __method and makes it clearer that this sends a PATCH request.