### PR TITLE
Rename console tests to commands tests and add new console tests assertions

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -60,8 +60,8 @@
 ## Testing
 
 * [Getting Started](testing/getting-started.md)
-* [Database Tests](testing/database-tests.md)
 * [HTTP Tests](testing/http-tests.md)
+* [Database Tests](testing/database-tests.md)
 * [Commands Tests](testing/commands-tests.md)
 * [Console Tests](testing/console-tests.md)
 * [Mocking](testing/mocking.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -60,8 +60,9 @@
 ## Testing
 
 * [Getting Started](testing/getting-started.md)
-* [HTTP Tests](testing/http-tests.md)
 * [Database Tests](testing/database-tests.md)
+* [HTTP Tests](testing/http-tests.md)
+* [Commands Tests](testing/commands-tests.md)
 * [Console Tests](testing/console-tests.md)
 * [Mocking](testing/mocking.md)
 * [Extending](testing/extending.md)

--- a/features/notifications.md
+++ b/features/notifications.md
@@ -276,8 +276,8 @@ Some blocks or elements might not be yet available in `slackblocks`, but most of
 
 You should define the related `route_notification_for_slack` method on your notifiable to return either
 
-* a webhook URL or a list of webhook URLs (if you're using [Incoming Webhooks](../#slack-incoming-webhooks))
-* a channel name/ID or a list of channels names/IDs (if you're using [Slack Web API](../#slack-web-api))
+* a webhook URL or a list of webhook URLs (if you're using [Incoming Webhooks](#slack-incoming-webhooks))
+* a channel name/ID or a list of channels names/IDs (if you're using [Slack Web API](#slack-web-api))
 
 ```python
 class User(Model, Notifiable):

--- a/features/package-development.md
+++ b/features/package-development.md
@@ -377,7 +377,7 @@ $ pip install super-awesome-package
 
 Then you should **follow package installation guidelines** but often it will consist in:
 
-- registering the package [Service Provider](#) in your project:
+- registering the package [Service Provider](/architecture/service-providers.md) in your project:
 
 ```python
 from super_awesome_package.providers import SuperAwesomeProvider

--- a/features/views.md
+++ b/features/views.md
@@ -22,7 +22,7 @@ class WelcomeController(Controller):
 
   def show(self, view: View):
     view.render('welcome', {
-    	"name": "Joe"  
+    	"name": "Joe"
     })
 ```
 
@@ -38,7 +38,7 @@ class WelcomeController(Controller):
   # Template is templates/greetings/welcome.html
   def show(self, view: View):
     view.render('greeting.welcome', {
-    	"name": "Joe"  
+    	"name": "Joe"
     })
 ```
 
@@ -192,7 +192,7 @@ You can access the session here:
 ```
 
 {% hint style="success" %}
-Learn more about session in the [Session](../advanced/sessions.md) documentation.
+Learn more about session in the [Session](/advanced/sessions.md) documentation.
 {% endhint %}
 
 ## Config
@@ -275,7 +275,7 @@ class UserModelProvider(ServiceProvider):
         return item.replace(' ', '-')
 ```
 
-> Make sure that you add filters in a [Service Provider](../architectural-concepts/service-providers.md) that has `wsgi=False` set. This prevents filters from being added on every single request which is not needed.
+> Make sure that you add filters in a [Service Provider](/architecture/service-providers.md) that has `wsgi=False` set. This prevents filters from being added on every single request which is not needed.
 
 # View Tests
 
@@ -508,7 +508,7 @@ Line Statements:
 <!-- components/base.html -->
 <html>
     <head>
-        @block css 
+        @block css
         <!-- block named "css" defined in child template will be inserted here -->
         @endblock
     </head>
@@ -551,14 +551,14 @@ Using alternative Jinja2 syntax:
 <!-- components/base.html -->
 <html>
     <head>
-        {% block css %} 
+        {% block css %}
         <!-- block named "css" defined in child template will be inserted here -->
         {% endblock %}
     </head>
 
 <body>
     <div class="container">
-        {% block content %} 
+        {% block content %}
         <!-- block named "content" defined in child template will be inserted here -->
         {% endblock %}
     </div>

--- a/prologue/create-a-blog.md
+++ b/prologue/create-a-blog.md
@@ -1,4 +1,4 @@
-This section of the documentation will contain various tutorials. These are guides that are designed to take you from beginning to end on building various types of projects with Masonite. We may not explain things in much detail for each section as this part of the documentation is designed to just get you familiar with the inner workings of Masonite. 
+This section of the documentation will contain various tutorials. These are guides that are designed to take you from beginning to end on building various types of projects with Masonite. We may not explain things in much detail for each section as this part of the documentation is designed to just get you familiar with the inner workings of Masonite.
 
 Since this section of the documentation is designed to just get you up and coding with Masonite, any further explanations that should be presented are inside various "hint blocks." Once you are done with the tutorial or simply want to learn more about a topic it is advised that you go through each hint block and follow the links to dive deeper into the reference documentation which does significantly more explaining.
 
@@ -44,7 +44,7 @@ ROUTES = [
 We'll talk more about the controller in a little bit.
 
 {% hint style="success" %}
-You can read more about routes in the [Routing](the-basics/routing.md) documentation
+You can read more about routes in the [Routing](/the-basics/routing.md) documentation
 {% endhint %}
 
 ### Creating our Route:

--- a/prologue/how-to-contribute.md
+++ b/prologue/how-to-contribute.md
@@ -8,13 +8,13 @@ This is not an exhaustive list and not the only ways to contribute but they are 
 
 ## Contributing to Development
 
-Of course the project requires contributions to the main development aspects but it's not the only way. But if you would like to contribute to development then a great way to get started is to simply read through this documentation. Get acquainted with how the framework works, how [Controllers](broken-reference) and [Routing](../features/routing.md) work and read the [Architectural Concepts](broken-reference) documentation starting with the [Request Lifecycle](broken-reference), then the [Service Providers](broken-reference) and finally the [Service Container](broken-reference).
+Of course the project requires contributions to the main development aspects but it's not the only way. But if you would like to contribute to development then a great way to get started is to simply read through this documentation. Get acquainted with how the framework works, how [Controllers](/features/controllers.md) and [Routing](/features/routing.md) work and read architectural concepts starting with the [Request Lifecycle](/features/request.md), then the [Service Providers](/architecture/service-providers.md) and finally the [Service Container](/architecture/service-containers.md).
 
-It would also be good to read about the [Release Cycle](release-cycle.md) to get familiar with how Masonite does releases (SemVer and RomVer).
+It would also be good to read about the [Release Cycle](/prologue/release-cycle.md) to get familiar with how Masonite does releases (SemVer and RomVer).
 
 ## Become a Feature Maintainer
 
-Feature Maintainers are people who are in charge of specific features (such as [Caching](broken-reference) or [Creating Packages](broken-reference)). These developers will be in charge of reviewing PR's and merging them into the development branch and also have direct contact with the repository owner to discuss.
+Feature Maintainers are people who are in charge of specific features (such as [Caching](/features/cache.md) or [Developing Packages](/features/package-development.md)). These developers will be in charge of reviewing PR's and merging them into the development branch and also have direct contact with the repository owner to discuss.
 
 Feature maintainers must already have significant contributions to development of the repository they are trying to be a Feature Maintainer for. Although they do not have to be contributors to the actual feature they plan to maintain.
 

--- a/testing/commands-tests.md
+++ b/testing/commands-tests.md
@@ -1,6 +1,6 @@
 # Commands Tests
 
-You can test your [custom commands](../features/commands/) running in console with `craft` test helper.
+You can test your [custom commands](/features/commands.md) running in console with `craft` test helper.
 
 ```python
 def test_my_command(self):

--- a/testing/commands-tests.md
+++ b/testing/commands-tests.md
@@ -1,0 +1,69 @@
+# Commands Tests
+
+You can test your [custom commands](../features/commands/) running in console with `craft` test helper.
+
+```python
+def test_my_command(self):
+    self.craft("my_command", "arg1 arg2").assertSuccess()
+```
+
+This will programmatically run the command if it has been registered in your project and assert that no errors has been reported.
+
+### Available Assertions
+
+The following assertions are available when testing command with `craft`.
+
+* [assertSuccess](commands-tests.md#assertsuccess)
+* [assertHasErrors](commands-tests.md#asserthaserrors)
+* [assertOutputContains](commands-tests.md#assertoutputcontains)
+* [assertExactOutput](commands-tests.md#assertexactoutput)
+* [assertOutputMissing](commands-tests.md#assertoutputmissing)
+* [assertExactErrors](commands-tests.md#assertexacterrors)
+
+#### assertSuccess
+
+Assert that command exited with code 0 meaning that it ran successfully.
+
+```python
+self.craft("my_command").assertSuccess()
+```
+
+#### assertHasErrors
+
+Assert command output has errors.
+
+```python
+self.craft("my_command").assertHasErrors()
+```
+
+#### assertOutputContains
+
+Assert command output contains the given string.
+
+```python
+self.craft("my_command").assertOutputContains(output)
+```
+
+#### assertExactOutput
+
+Assert command output to be exactly the same as the given reference output. Be careful to add eventual  line endings characters when using this assertion method.
+
+```python
+self.craft("my_command").assertExactOutput(output)
+```
+
+#### assertOutputMissing
+
+Assert command output does not contain the given reference output.
+
+```python
+self.craft("my_command").assertOutputMissing(output)
+```
+
+#### assertExactErrors
+
+Assert command output has exactly the given errors.
+
+```python
+self.craft("my_command").assertExactErrors(errors)
+```

--- a/testing/console-tests.md
+++ b/testing/console-tests.md
@@ -3,8 +3,8 @@
 You can test what has been output to standard console during Masonite unit tests thanks to useful
 console assertions.
 
-Output here is the standard output often name `stdout`.
-Error here is the standard error often name `stderr`.
+Output here is the standard output often named `stdout`.
+Error here is the standard error often named `stderr`.
 
 External packages, prints in your code can output content in console (as output or error).
 

--- a/testing/console-tests.md
+++ b/testing/console-tests.md
@@ -6,8 +6,12 @@ console assertions.
 Output here is the standard output often name `stdout`.
 Error here is the standard error often name `stderr`.
 
-External packages, prints in your code or [Masonite commands](../features/commands/) can output content
-in console (as output or error).
+External packages, prints in your code can output content in console (as output or error).
+
+{% hint style="warning" %}
+If you want to assert content output by a Masonite command you should use [Commands Tests](/testing/commands-tests.md#available-assertions) assertions instead.
+{% endhint %}
+
 
 ### Available Assertions
 

--- a/testing/console-tests.md
+++ b/testing/console-tests.md
@@ -1,69 +1,80 @@
 # Console Tests
 
-You can test your [custom commands](../features/commands/) running in console with `craft` test helper.
+You can test what has been output to standard console during Masonite unit tests thanks to useful
+console assertions.
 
-```python
-def test_my_command(self):
-    self.craft("my_command", "arg1 arg2").assertSuccess()
-```
+Output here is the standard output often name `stdout`.
+Error here is the standard error often name `stderr`.
 
-This will programmatically run the command if it has been registered in your project and assert that no errors has been reported.
+External packages, prints in your code or [Masonite commands](../features/commands/) can output content
+in console (as output or error).
 
 ### Available Assertions
 
-The following assertions are available when testing command with `craft`.
+The following assertions are available:
 
-* [assertSuccess](console-tests.md#assertsuccess)
-* [assertHasErrors](console-tests.md#asserthaserrors)
-* [assertOutputContains](console-tests.md#assertoutputcontains)
-* [assertExactOutput](console-tests.md#assertexactoutput)
-* [assertOutputMissing](console-tests.md#assertoutputmissing)
-* [assertExactErrors](console-tests.md#assertexacterrors)
+* [assertConsoleEmpty](console-tests.md#assertconsoleempty)
+* [assertConsoleNotEmpty](console-tests.md#assertconsolenotempty)
+* [assertConsoleExactOutput](console-tests.md#assertconsoleexactoutput)
+* [assertConsoleOutputContains](console-tests.md#assertconsoleoutputcontains)
+* [assertConsoleOutputMissing](console-tests.md#assertconsoleoutputmissing)
+* [assertConsoleHasErrors](console-tests.md#assertconsolehaserrors)
+* [assertConsoleExactError](console-tests.md#assertconsoleexacterror)
+* [assertConsoleErrorContains](console-tests.md#assertconsoleerrorcontains)
 
-#### assertSuccess
+#### assertConsoleEmpty
 
-Assert that command exited with code 0 meaning that it ran successfully.
+Assert that nothing has been printed to the console.
+
+#### assertConsoleNotEmpty
+
+Assert that something has been printed to the console (output or error).
+
+#### assertConsoleExactOutput
+
+Assert that console standard output is equal to given output.
 
 ```python
-self.craft("my_command").assertSuccess()
+print("Success !")
+self.assertConsoleExactOutput("Success !\n")
 ```
 
-#### assertHasErrors
+#### assertConsoleOutputContains
 
-Assert command output has errors.
+Assert that console standard output contains given output.
 
 ```python
-self.craft("my_command").assertHasErrors()
+print("Success !")
+self.assertConsoleOutputContains("Success")
 ```
 
-#### assertOutputContains
+#### assertConsoleOutputMissing
 
-Assert command output contains the given string.
+Assert that console standard output does not contain the given output.
 
 ```python
-self.craft("my_command").assertOutputContains(output)
+print("Success !")
+self.assertConsoleOutputMissing("hello")
 ```
 
-#### assertExactOutput
+#### assertConsoleHasErrors
 
-Assert command output to be exactly the same as the given reference output. Be careful to add eventual  line endings characters when using this assertion method.
+Assert that something has been output to console standard error.
+
+#### assertConsoleExactError
+
+Assert that console standard error is equal to given error.
 
 ```python
-self.craft("my_command").assertExactOutput(output)
+print("An error occured !", file=sys.stderr)
+self.assertConsoleExactError("An error occured !\n")
 ```
 
-#### assertOutputMissing
+#### assertConsoleErrorContains
 
-Assert command output does not contain the given reference output.
-
-```python
-self.craft("my_command").assertOutputMissing(output)
-```
-
-#### assertExactErrors
-
-Assert command output has exactly the given errors.
+Assert that console standard error contains given error.
 
 ```python
-self.craft("my_command").assertExactErrors(errors)
+print("An error occured !", file=sys.stderr)
+self.assertConsoleErrorContains("error")
 ```

--- a/testing/mocking.md
+++ b/testing/mocking.md
@@ -16,8 +16,8 @@ a quick and simple implementation is ran, often offering the ability to inspect 
 
 Available features that can be mocked (for now) are:
 
-- [Mail](/features/mail)
-- [Notification](/features/notifications)
+- [Mail](/features/mail.md)
+- [Notification](/features/notifications.md)
 
 ## Mocking Mail
 


### PR DESCRIPTION
- Rename `Console Tests` as `Commands tests` as it's indeed more commands tests than console tests.
- Add `Console Tests` new assertions
- Fixed a lot of broken links 😉 