### PR TITLE
fix: package development view namespace

### DIFF
--- a/architecture/service-container.md
+++ b/architecture/service-container.md
@@ -44,7 +44,7 @@ The service container is available in the `Request` object and can be retrieved 
 
 ```python
 def show(self, request: Request):
-    request.app() # will return the service container
+    request.app # will return the service container
 ```
 
 ### Simple Binding
@@ -218,7 +218,7 @@ def randomFunction(view: View):
     print(view)
 
 def show(self, request: Request):
-    request.app().resolve(randomFunction) # Will print the View object
+    request.app.resolve(randomFunction) # Will print the View object
 ```
 
 {% hint style="warning" %}

--- a/features/package-development.md
+++ b/features/package-development.md
@@ -320,7 +320,7 @@ def configure(self):
     (
         self.root("super_awesome_package")
         .name("super_awesome")
-        .views("assets")
+        .assets("assets")
     )
 ```
 

--- a/features/package-development.md
+++ b/features/package-development.md
@@ -298,13 +298,13 @@ def configure(self):
     )
 ```
 
-Views will be available in controllers:
-
+Views will be available in controllers under a namespace. Use `your_package_name:template` to reference your view:
+ 
 ```python
 class ProjectController(Controller):
 
     def index(self, view: View):
-        return view.render("super_awesome.admin.index")
+        return view.render("super_awesome:admin.index")
 ```
 
 If you want to allow users to publish the view file into their own project so they can tweak them you should add `publish=True` argument. The [package publish](#publishing-resources) command will publish the views files into the defined project views folder. With the default project settings it would be in `templates/vendor/super_awesome/admin/index.html`.


### PR DESCRIPTION
I had a problem creating a package because views were not recognized and I realized that the `View` class needs to know the namespace of the view to find it.

Reference: https://github.com/MasoniteFramework/masonite/blob/e8e55e5fdced9f28cc8acb1577457a490e5b4b74/src/masonite/views/view.py#L194